### PR TITLE
Adding urllib3 version as a requirement

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,3 @@
 pydantic==1.9.1
 requests==2.28.1
-urllib3==1.26.9
+urllib3==1.26.11

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,3 @@
 pydantic==1.9.1
 requests==2.28.1
+urllib3==1.26.9


### PR DESCRIPTION
Although the requests is updated I found urllib3 version is also needed to be updated to work with shroomdk