### PR TITLE
Add SDK Package Info to Better Assist with Debugging the PythonSDK

### DIFF
--- a/python/shroomdk/models/query.py
+++ b/python/shroomdk/models/query.py
@@ -5,12 +5,24 @@ from pydantic import BaseModel, Field
 
 class Query(BaseModel):
     sql: str = Field(None, description="SQL query to execute")
-    ttl_minutes: Optional[int] = Field(None, description="The number of minutes to cache the query results")
-    timeout_minutes: Optional[int] = Field(None, description="The number of minutes to timeout the query")
-    retry_interval_seconds: Optional[Union[int, float]] = Field(1, description="The number of seconds to use between retries")
+    ttl_minutes: Optional[int] = Field(
+        None, description="The number of minutes to cache the query results"
+    )
+    timeout_minutes: Optional[int] = Field(
+        None, description="The number of minutes to timeout the query"
+    )
+    retry_interval_seconds: Optional[Union[int, float]] = Field(
+        1, description="The number of seconds to use between retries"
+    )
     cached: Optional[bool] = Field(
         None,
         description="An override on the cache. A value of true will Re-Execute the query.",
     )
     page_size: int = Field(None, description="The number of results to return per page")
     page_number: int = Field(None, description="The page number to return")
+    sdk_package: Optional[str] = Field(
+        None, description="The SDK package used for the query"
+    )
+    sdk_version: Optional[str] = Field(
+        None, description="The SDK version used for the query"
+    )

--- a/python/shroomdk/shroomdk.py
+++ b/python/shroomdk/shroomdk.py
@@ -4,6 +4,9 @@ from shroomdk.models import Query
 
 API_BASE_URL = "https://api.flipsidecrypto.com"
 
+SDK_VERSION = "1.0.2"
+SDK_PACKAGE = "python"
+
 
 class ShroomDK(object):
     def __init__(self, api_key: str, api_base_url: str = API_BASE_URL):
@@ -30,5 +33,7 @@ class ShroomDK(object):
                 page_size=page_size,
                 page_number=page_number,
                 cached=cached,
+                sdk_package=SDK_PACKAGE,
+                sdk_version=SDK_VERSION,
             )
         )


### PR DESCRIPTION
This PR adds two parameters to the API request:

- `sdk_package` 
- `sdk_version`

The goal of this is to isolate issues and better assist users that are reporting issues.