### PR TITLE
JS Update entry point path

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -2,8 +2,8 @@
   "name": "@flipsidecrypto/sdk",
   "version": "1.1.1",
   "description": "The official Flipside Crypto SDK",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/flipsidecrypto/sdk.git"


### PR DESCRIPTION
Hey there Flipside gang! I was working on a little side project that uses ShroomDK and ran into some issues with importing the module. 

<img width="594" alt="Screen Shot 2022-11-21 at 2 34 53 PM" src="https://user-images.githubusercontent.com/33527785/203153304-95ae355b-70fa-4767-8bdc-801d8b0b2645.png">

In my node modules, the index of the package is found in @flipsidecrypto/sdk/dist/src/index.js, but the base package.json has the main and type entry points as just dist/index.js. Making the change I've proposed solves the issue in my case. 

I'm not entirely sure if this is a common issue for people as I did not find anyone else mentioning it in #sdk-help, but figured I would raise this issue if others are indeed facing the same problem. Also feel free to close this and just shut me down if I am off-base here. :)