### PR TITLE
Python SDK: Bump Pydantic to Version 1.10.9

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,2 @@
-pydantic==1.10.7
+pydantic==1.10.9
 requests==2.29.0


### PR DESCRIPTION
This PR bumps the version of Pydantic to Version 1.10.9 to resolve an issue in Pydantic version 1.10.7.